### PR TITLE
Updated PHP template to utilize PHPDoc

### DIFF
--- a/template/header/PHP.tmpl
+++ b/template/header/PHP.tmpl
@@ -1,9 +1,7 @@
 <?php
-/* 
-* @Author: {{author}}
-* @Date:   {{create_time}}
-* @Last Modified by:   {{last_modified_by}}
-* @Last Modified time: {{last_modified_time}}
-*/
-?>
-
+/**
+ * @Author: {{author}}
+ * @Date:   {{create_time}}
+ * @Last Modified by:   {{last_modified_by}}
+ * @Last Modified time: {{last_modified_time}}
+ */


### PR DESCRIPTION
Link to PHPDoc http://en.wikipedia.org/wiki/PHPDoc
PHPDoc is most used comment style for php and closing php tag, in a file containing only php, is not recommended, as in PSR-2: http://www.php-fig.org/psr/psr-2/
