### PR TITLE
Fix new file command

### DIFF
--- a/FileHeader.py
+++ b/FileHeader.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # @Author: Lime
 # @Date:   2013-10-28 13:39:48
-# @Last Modified by:   qkdreyer
-# @Last Modified time: 2017-08-14 16:48:32
+# @Last Modified by:   Radek Krzak
+# @Last Modified time: 2017-10-08 17:30:41
 
 import os
 import sys
@@ -465,7 +465,7 @@ class FileHeaderNewFileCommand(sublime_plugin.WindowCommand):
             sublime.error_message('File exists!')
             return
 
-        header = get_header_content(syntax_type, path)
+        header = render_template(syntax_type, options={'path': path})
 
         try:
             with open(path, 'w+') as f:


### PR DESCRIPTION
Last [commit](https://github.com/shiyanhui/FileHeader/commit/5e164be616824818c752f40155c58badf69c662b#diff-d95acaab442013e702bfed0ca89aaf10L350) replaced `header = render_template(syntax_type, options={'path': path})` with `header = get_header_content(syntax_type, path)`.

Adding content of base template on file creation no longer worked, since `get_header_content` function was only returning the content of the header template.

closes #85 