### PR TITLE
fix(shell): validation SC2148

### DIFF
--- a/template/header/ShellScript.tmpl
+++ b/template/header/ShellScript.tmpl
@@ -1,3 +1,4 @@
+#!/bin/bash
 # @Author: {{author}}
 # @Date:   {{create_time}}
 # @Last Modified by:   {{last_modified_by}}


### PR DESCRIPTION
### 1. Summary

I add `#!/bin/bash` in beginning of Shell template.

### 2. Argumentation

Shebang must be in shell scripts.

Please, read [**ShellCheck SC2148**](https://github.com/koalaman/shellcheck/wiki/SC2148).

### 3. Behavior before pull request

```bash
# @Author: SashaChernykh
# @Date:   2018-04-28 08:58:09
# @Last Modified by:   SashaChernykh
# @Last Modified time: 2018-04-28 08:58:09
```

### 4. Behavior after pull request

```bash
#!/bin/bash
# @Author: SashaChernykh
# @Date:   2018-04-28 08:58:09
# @Last Modified by:   SashaChernykh
# @Last Modified time: 2018-04-28 08:58:09
```

### 5. Testing environment

+ Sublime Text Build 3143
+ FileHeader 2.0.5

Thanks.