### PR TITLE
Rename `get_user` to `get_author`. Add `get_email`

### DIFF
--- a/FileHeader.py
+++ b/FileHeader.py
@@ -225,6 +225,22 @@ def get_author():
     return author
 
 
+def get_email():
+    '''Get email'''
+
+    email = None
+
+    prefix = 'cd %s && git ' % get_dir_path()
+
+    output, error = getOutputError(prefix + 'status')
+
+    if not error:
+        output, error = getOutputError(prefix + 'config --get user.email')
+        if not error and output:
+            email = output
+    return email
+
+
 def get_project_name():
     '''Get project name'''
 
@@ -331,6 +347,10 @@ def get_args(syntax_type, options={}):
         args.update({'author': author})
     if 'last_modified_by' not in args:
         args.update({'last_modified_by': author})
+
+    email = get_email()
+    if 'email' not in args:
+        args.update({'email': email})
 
     return args
 

--- a/FileHeader.py
+++ b/FileHeader.py
@@ -209,18 +209,20 @@ def get_strftime():
     return format
 
 
-def get_user():
-    '''Get user'''
+def get_author():
+    '''Get author'''
 
-    user = getpass.getuser()
-    output, error = getOutputError(
-        'cd {0} && git status'.format(get_dir_path()))
+    author = getpass.getuser()
+
+    prefix = 'cd %s && git ' % get_dir_path()
+
+    output, error = getOutputError(prefix + 'status')
 
     if not error:
-        output, error = getOutputError('git config --get user.name')
+        output, error = getOutputError(prefix + 'config --get user.name')
         if not error and output:
-            user = output
-    return user
+            author = output
+    return author
 
 
 def get_project_name():
@@ -324,11 +326,11 @@ def get_args(syntax_type, options={}):
     if IS_ST3:
         args.update({'project_name': get_project_name()})
 
-    user = get_user()
+    author = get_author()
     if 'author' not in args:
-        args.update({'author': user})
+        args.update({'author': author})
     if 'last_modified_by' not in args:
-        args.update({'last_modified_by': user})
+        args.update({'last_modified_by': author})
 
     return args
 

--- a/FileHeader.py
+++ b/FileHeader.py
@@ -209,36 +209,35 @@ def get_strftime():
     return format
 
 
-def get_author():
-    '''Get author'''
+def get_user_data_from_git(attr, default=None):
+    '''Get attr of 'user' object from GIT's config'''
 
-    author = getpass.getuser()
+    if not attr:
+        return default
 
+    value = default
     prefix = 'cd %s && git ' % get_dir_path()
 
     output, error = getOutputError(prefix + 'status')
 
     if not error:
-        output, error = getOutputError(prefix + 'config --get user.name')
+        output, error = getOutputError(prefix + 'config --get user.%s' % attr)
         if not error and output:
-            author = output
-    return author
+            value = output
+
+    return value
+
+
+def get_author():
+    '''Get author'''
+
+    return get_user_data_from_git('name', getpass.getuser())
 
 
 def get_email():
     '''Get email'''
 
-    email = None
-
-    prefix = 'cd %s && git ' % get_dir_path()
-
-    output, error = getOutputError(prefix + 'status')
-
-    if not error:
-        output, error = getOutputError(prefix + 'config --get user.email')
-        if not error and output:
-            email = output
-    return email
+    return get_user_data_from_git('email')
 
 
 def get_project_name():
@@ -348,9 +347,8 @@ def get_args(syntax_type, options={}):
     if 'last_modified_by' not in args:
         args.update({'last_modified_by': author})
 
-    email = get_email()
     if 'email' not in args:
-        args.update({'email': email})
+        args.update({'email': get_email()})
 
     return args
 

--- a/FileHeader.sublime-settings
+++ b/FileHeader.sublime-settings
@@ -145,7 +145,7 @@
             Author's email
 
             FileHeader will set it automatically. If it's in
-            a git repository and the `user.email` has been set, `autor`
+            a git repository and the `user.email` has been set, `email`
             will set to `user.email`, otherwise it will be set to `None`.
 
             Can be set custom.
@@ -202,11 +202,6 @@
 
             Can't be set custom.
         */
-
-        /*
-        Email
-        */
-        "email": "email@example.com"
 
         // You can add more here......
     },

--- a/FileHeader.sublime-settings
+++ b/FileHeader.sublime-settings
@@ -140,6 +140,16 @@
 
             Can be set custom.
 
+        - email
+
+            Author's email
+
+            FileHeader will set it automatically. If it's in
+            a git repository and the `user.email` has been set, `autor`
+            will set to `user.email`, otherwise it will be set to `None`.
+
+            Can be set custom.
+
         - last_modified_by
 
             The file last modified by who? It is specially useful when


### PR DESCRIPTION
Rename `get_user` to `get_author`. Because it more verbose then old name.
Also fix bug with `git config` command: it runed out of project's dir.

Add `get_email` which similar to `get_author`: get email from project's GIT config.