### PR TITLE
Fix issue with unicode characters in tmpl file

### DIFF
--- a/FileHeader.py
+++ b/FileHeader.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # @Author: Lime
 # @Date:   2013-10-28 13:39:48
-# @Last Modified by:   qkdreyer
-# @Last Modified time: 2017-08-14 16:48:32
+# @Last Modified by:   Abad Vera
+# @Last Modified time: 2019-09-26 09:53:39
 
 import os
 import sys
@@ -179,8 +179,8 @@ def get_template_part(syntax_type, part):
             tmplate_path = path
 
     try:
-        with open(tmplate_path, 'r') as f:
-            contents = f.read()
+        with open(tmplate_path, 'rb') as f:
+            contents = f.read().decode('utf-8')
     except:
         contents = ''
     return contents
@@ -488,8 +488,8 @@ class FileHeaderNewFileCommand(sublime_plugin.WindowCommand):
         header = get_header_content(syntax_type, path)
 
         try:
-            with open(path, 'w+') as f:
-                f.write(header)
+            with open(path, 'w+b') as f:
+                f.write(header.encode('utf-8'))
 
         except Exception as e:
             sublime.error_message(str(e))
@@ -563,15 +563,15 @@ class BackgroundAddHeaderThread(threading.Thread):
         syntax_type = get_syntax_type(self.path)
 
         try:
-            with open(self.path, 'r') as f:
-                file = f.read()
+            with open(self.path, 'rb') as f:
+                file = f.read().decode('utf-8')
 
             if not template_header_exists(file, syntax_type):
                 header_content = get_header_content(
                     syntax_type, self.path, file)
                 contents = get_file_content(file, syntax_type, header_content)
-                with open(self.path, 'w') as f:
-                    f.write(contents)
+                with open(self.path, 'wb') as f:
+                    f.write(contents.encode('utf-8'))
 
         except Exception as e:
             sublime.error_message(str(e))


### PR DESCRIPTION
If a unicode character is in the TMPL file, then the FileHeader plugin crashes and does not add the template. That is because it thinks all characters in the file are in ASCII format. Loading the file in UTF-8 formate resolves this issue.